### PR TITLE
SSL Certificate

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -38,7 +38,7 @@ en:
       updated_not_active: "Your password has been changed successfully."
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
-      signed_up: "Welcome! You have signed up successfully."
+      signed_up: " Welcome !"
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."


### PR DESCRIPTION
Tanise.

Victor.

Nesta PR fiz duas modificações:

1. Configurei um free certificado SSL no Heroku e forcei o SSL no Rails, conforme tutorial da LeWagon:

Agora o site tem o acesso seguro com HTTPS:// , em vez de HTTP:// . 

A diferença é o “S” (security).

2. Fiz uma alteração no registrations, signed_up, para “ Welcome ! “. Só para teste. Depois podemos ajustar esses alertas.